### PR TITLE
Added SSL Cert Verification option

### DIFF
--- a/wbgapi/__init__.py
+++ b/wbgapi/__init__.py
@@ -31,7 +31,9 @@ endpoint = 'https://api.worldbank.org/v2'
 lang = 'en'
 per_page = 1000          # you can increase this if you start getting 'service unavailable' messages, which can mean you're sending too many requests per minute
 db = 2
+
 proxies = None           # see https://requests.readthedocs.io/en/master/user/advanced/#proxies for format
+verify = True            # see https://docs.python-requests.org/en/latest/user/advanced/#ssl-cert-verification
 
 # The maximum URL length is 1500 chars before it reports a server error. Internally we use a smaller
 # number for head room as well as to provide for the query string
@@ -520,7 +522,7 @@ def _queryAPI(url):
     '''
     global proxies
 
-    response = requests.get(url, proxies=proxies)
+    response = requests.get(url, proxies=proxies, verify=verify)
     if response.status_code != 200:
         raise APIError(url, response.reason, response.status_code)
 


### PR DESCRIPTION
Added the option to use a custom SSL Certificate when using proxies. This fix passes a custom verify option to the python requests default verify parameter.
Otherwise, the package would have thrown an SSL Error when using proxies since the python requests module wasn't able to verify the SSL Certs and therefore  authenticate the HTTPS Requests

@tgherzog Would be great if you could take a look at it.