### PR TITLE
Mark pattern as raw string

### DIFF
--- a/wbgapi/__init__.py
+++ b/wbgapi/__init__.py
@@ -636,7 +636,7 @@ def abbreviate(text, q=None, padding=80):
     match = None
     if q and padding is not None:
         if padding > 0:
-            pattern = '(?<!\w).{{0,{len}}}{term}.{{0,{len}}}(?!\w)'.format(term=re.escape(q), len=padding)
+            pattern = r'(?<!\w).{{0,{len}}}{term}.{{0,{len}}}(?!\w)'.format(term=re.escape(q), len=padding)
             match = re.search(pattern, text, re.IGNORECASE)
         else:
             match = re.search(q, text, re.IGNORECASE)


### PR DESCRIPTION
Hello @tgherzog!

Thank you for this awesome package, which we use a lot in our work. I'm submitting a very small fix to get rid of a warning:
`SyntaxWarning: invalid escape sequence '\w' and '\W'`

Python string literals interpret \ as an escape character unless the string is marked as a raw string (with prefix r). Adding `r` just before the string fixes the problem.