### PR TITLE
Mark pattern as raw string

### DIFF
--- a/wbgapi/__init__.py
+++ b/wbgapi/__init__.py
@@ -636,7 +636,7 @@ def abbreviate(text, q=None, padding=80):
     match = None
     if q and padding is not None:
         if padding > 0:
-            pattern = '(?<!\w).{{0,{len}}}{term}.{{0,{len}}}(?!\w)'.format(term=re.escape(q), len=padding)
+            pattern = r'(?<!\w).{{0,{len}}}{term}.{{0,{len}}}(?!\w)'.format(term=re.escape(q), len=padding)
             match = re.search(pattern, text, re.IGNORECASE)
         else:
             match = re.search(q, text, re.IGNORECASE)


### PR DESCRIPTION
As noted in #37:
Python string literals interpret \ as an escape character unless the string is marked as a raw string (with prefix r). Adding `r` just before the string fixes the problem.

Since 3.12, this now emits a syntax warning, noting that it will eventually raise a syntax error. 
https://docs.python.org/3/whatsnew/3.12.html#other-language-changes